### PR TITLE
Adding @mixin make-col-ready() to grid.scss

### DIFF
--- a/assets/scss/mixins/_grid.scss
+++ b/assets/scss/mixins/_grid.scss
@@ -1,4 +1,14 @@
 // Make column
+@mixin make-col-ready() {
+  position: relative;
+  // Prevent columns from becoming too narrow when at smaller grid tiers by
+  // always setting `width: 100%;`. This works because we use `flex` values
+  // later on to override this initial width.
+  width: 100%;
+  min-height: 1px; // Prevent collapsing
+  padding-right: ($grid-gutter-width / 2);
+  padding-left: ($grid-gutter-width / 2);
+}
 
 @mixin make-col($size) {
   flex: 0 0 percentage($size / $grid-columns);


### PR DESCRIPTION
Despite being referenced in the docs (http://daemonite.github.io/material/docs/4.0/layout/grid/#mixins), make-col-ready() was missing from the actual file.
All I did was copy the @mixin from the latest Bootstrap v4-release (https://github.com/twbs/bootstrap/blob/v4.0.0/scss/mixins/_grid.scss).

(PS: I see most of the other mixins here deviate from the bootstrap version, but I'm assuming there's a reason for that).