### PR TITLE
hide platform-native styling of select element

### DIFF
--- a/assets/scss/material/_text-field.scss
+++ b/assets/scss/material/_text-field.scss
@@ -84,6 +84,8 @@
 // Select and textarea
 
 %form-select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
 
   @include media-moz-webkit {


### PR DESCRIPTION
In my chrome browser(Version 75.0.3770.100), `select element` always showing native arrow drop-down icon. This PR can fixed this issue and hide native arrow drop-down icon.